### PR TITLE
add config option to prevent placeholders being replaced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
             <url>https://repo.repsy.io/mvn/kiran/tweetzy</url>
         </repository>
         <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
@@ -51,9 +55,15 @@
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+            <scope>provided</scope> <!-- Provided by Spigot -->
         </dependency>
         <dependency>
             <groupId>${flight.path}</groupId>

--- a/src/main/java/ca/tweetzy/vouchers/listeners/VoucherListeners.java
+++ b/src/main/java/ca/tweetzy/vouchers/listeners/VoucherListeners.java
@@ -26,6 +26,7 @@ import ca.tweetzy.vouchers.api.events.VoucherRedeemResult;
 import ca.tweetzy.vouchers.api.voucher.Voucher;
 import ca.tweetzy.vouchers.gui.GUIConfirm;
 import ca.tweetzy.vouchers.hook.PAPIHook;
+import ca.tweetzy.vouchers.settings.Settings;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -144,6 +145,8 @@ public final class VoucherListeners implements Listener {
 
 	@EventHandler
 	public void onChat(final AsyncPlayerChatEvent event) {
-		event.setMessage(PAPIHook.tryReplace(event.getPlayer(), event.getMessage()));
+		if(Settings.REPLACE_PLACEHOLDERS_IN_CHAT.getBoolean()) {
+			event.setMessage(PAPIHook.tryReplace(event.getPlayer(), event.getMessage()));
+		}
 	}
 }

--- a/src/main/java/ca/tweetzy/vouchers/settings/Settings.java
+++ b/src/main/java/ca/tweetzy/vouchers/settings/Settings.java
@@ -32,6 +32,7 @@ public final class Settings extends FlightSettings {
 
 	public static final ConfigEntry LOG_VOUCHER_GIVE_STATUS = create("log voucher give status", true, "If true, vouchers will log if the voucher was placed in the user's inventory or dropped");
 	public static final ConfigEntry SHOW_VOUCHER_REWARD_INFO = create("show voucher reward info", true, "If true, vouchers will tell the player what they got");
+	public static final ConfigEntry REPLACE_PLACEHOLDERS_IN_CHAT = create("replace placeholders in chat", true, "If true, vouchers will replace PlaceholderAPI placeholders in chat messages");
 
 
 	public static void init() {


### PR DESCRIPTION
This adds a config option to prevent placeholders being replaced in chat for every user. Default setting is true, like the current behaviour.